### PR TITLE
update docker path to reflect upstream change

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -13,7 +13,7 @@ jobs:
     trigger: true
   - put: oracle-image-repository
     params:
-      build: oracle-image-git-repository/OracleInstantClient/dockerfiles/19
+      build: oracle-image-git-repository/OracleInstantClient/oraclelinux7/19
 - name: update-sql-client-image
   plan:
   - in_parallel:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -26,16 +26,6 @@ jobs:
   - put: sql-image-repo
     params:
       build: concourse-images/task/sql-image
-- name: s3-resource-simple-image
-  plan:
-    - get: alpine-image
-      params:
-        skip_download: true
-      trigger: true
-    - get: s3-resource-simple
-    - put: s3-resource-simple-repo
-      params:
-        build: s3-resource-simple
 
 - name: s3-resource-simple-image
   plan:


### PR DESCRIPTION
## Changes proposed in this pull request:
- update docker path to reflect upstream change

This keeps us on the same linux version. Oracle is now releasing OL8 images alongside the OL7, so if this works, I think we should try to upgrade this image to use OL8.

## security considerations
None