### PR TITLE
update image build scripts to set GOBIN to existing directory in PATH

### DIFF
--- a/task/concourse-tasks/scripts/build.sh
+++ b/task/concourse-tasks/scripts/build.sh
@@ -65,8 +65,6 @@ pushd "ruby-${RUBY_RELEASE_VERSION}"
 popd
 rm -f "ruby-${RUBY_RELEASE_VERSION}.tar.gz"
 
-
-
 # # Commented out pending https://bugs.launchpad.net/ubuntu/+source/ruby2.0/+bug/1777174
 # # # Set default versions of ruby and gem to 2.0 versions
 # # update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby2.0 1
@@ -127,6 +125,7 @@ mkdir -p /usr/local/go
 tar -xvzf "go$GO_VERSION.linux-amd64.tar.gz" -C /usr/local/go --strip-components=1
 ln -s /usr/local/go/bin/go /usr/local/bin/go
 ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+go env -w GOBIN=/usr/local/bin
 
 apt-get clean
 rm -rf /var/cache/apt

--- a/task/harden-concourse-tasks/scripts/build.sh
+++ b/task/harden-concourse-tasks/scripts/build.sh
@@ -36,7 +36,7 @@ echo "Updating system package registry"
 add-apt-repository ppa:rmescandon/yq
 apt-get -y update
 
-echo "Installing basic libraries and development utilities"
+# echo "Installing basic libraries and development utilities"
 apt-get -y -q install \
   build-essential \
   cmake \
@@ -83,8 +83,6 @@ pushd "ruby-${RUBY_RELEASE_VERSION}"
   make install
 popd
 rm -f "ruby-${RUBY_RELEASE_VERSION}.tar.gz"
-
-
 
 # # Commented out pending https://bugs.launchpad.net/ubuntu/+source/ruby2.0/+bug/1777174
 # # # Set default versions of ruby and gem to 2.0 versions
@@ -155,6 +153,8 @@ mkdir -p /usr/local/go
 tar -xvzf "go$GO_VERSION.linux-amd64.tar.gz" -C /usr/local/go --strip-components=1
 ln -s /usr/local/go/bin/go /usr/local/bin/go
 ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
+go env -w GOBIN=/usr/local/bin
 
 apt-get clean
 rm -rf /var/cache/apt

--- a/task/harden-concourse-tasks/scripts/build.sh
+++ b/task/harden-concourse-tasks/scripts/build.sh
@@ -36,7 +36,7 @@ echo "Updating system package registry"
 add-apt-repository ppa:rmescandon/yq
 apt-get -y update
 
-# echo "Installing basic libraries and development utilities"
+echo "Installing basic libraries and development utilities"
 apt-get -y -q install \
   build-essential \
   cmake \


### PR DESCRIPTION
## Changes proposed in this pull request:

- update image build scripts to set GOBIN to existing directory in PATH so that when packages are installed with `go install` they are available to be used in the shell

## security considerations

There is no security impact. This changes merely fixes the behavior of Go within the image. The same hardening steps still apply to the container images.
