### PR TITLE
update pipeline to self-fly and use credhub

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,9 +1,16 @@
 ---
 jobs:
+- name: set-self
+  plan:
+    - get: concourse-images
+      trigger: true
+    - set_pipeline: self
+      file: concourse-images/pipeline.yml
+
 - name: create-concourse-task-image
-  old_name: update-concourse-task-image
   plan:
   - get: concourse-images
+    passed: [set-self]
     trigger: true
   - get: concourse-image-version
     params: {bump: patch}
@@ -16,7 +23,6 @@ jobs:
     params: {file: concourse-image-version/version}
 
 - name: create-oracle-image
-  old_name: update-oracle-image-task
   plan:
   - get: oracle-image-git-repository
     trigger: true
@@ -31,11 +37,11 @@ jobs:
     params: {file: oracle-image-version/version}
 
 - name: create-sql-client-image
-  old_name: update-sql-client-image
   plan:
   - in_parallel:
       steps:
       - get: concourse-images
+        passed: [set-self]
         trigger: true
       - get: oracle-image-repository
         passed: [create-oracle-image]
@@ -51,7 +57,6 @@ jobs:
     params: {file: sql-client-image-version/version}
 
 - name: create-s3-resource-simple-image
-  old_name: s3-resource-simple-image
   plan:
     - get: s3-resource-simple-repository
     - get: s3-image-version
@@ -65,9 +70,9 @@ jobs:
       params: {file: s3-image-version/version}
 
 - name: create-hardened-concourse-task-staging-image
-  old_name: update-harden-concourse-task-image-staging
   plan:
   - get: harden-concourse-images-repo
+    passed: [set-self]
     trigger: true
   - get: hardened-concourse-image-staging-version
     params: {bump: patch}
@@ -97,10 +102,10 @@ jobs:
     params: {file: hardened-concourse-image-staging-version/version}
 
 - name: create-hardened-s3-resource-simple-staging-image
-  old_name: update-harden-s3-resource-simple-image-staging
   plan:
   - get: s3-resource-simple-repository
   - get: harden-concourse-images-repo
+    passed: [set-self]
     trigger: true
   - get: hardened-s3-resource-simple-image-version-staging
     params: {bump: patch}
@@ -130,7 +135,6 @@ jobs:
     params: {file: hardened-s3-resource-simple-image-version-staging/version}
 
 - name: hardened-container-bosh-development-jumpbox
-  old_name: harden-container-bosh-development
   plan:
   - get: ecr-harden-concourse-task-staging-repo
   - task: jumpbox
@@ -156,15 +160,15 @@ resources:
 - name: concourse-images
   type: git
   source:
-    uri: {{concourse-task-image-git-url}}
-    branch: {{concourse-task-image-git-branch}}
+    uri: ((concourse-task-image-git-url))
+    branch: ((concourse-task-image-git-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: harden-concourse-images-repo
   type: git
   source:
-    uri: {{concourse-task-image-git-url}}
-    branch: {{concourse-task-image-git-branch}}
+    uri: ((concourse-task-image-git-url))
+    branch: ((concourse-task-image-git-branch))
 
 - name: ecr-harden-concourse-task-staging-repo
   type: registry-image
@@ -187,110 +191,110 @@ resources:
 - name: sql-image-repo
   type: docker-image
   source:
-    email: {{docker-email}}
-    username: {{docker-username}}
-    password: {{docker-password}}
-    repository: {{sql-image-repository}}
+    email: ((docker-email))
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: ((sql-image-repository))
 
 - name: concourse-tasks-image-repo
   type: docker-image
   source:
-    email: {{docker-email}}
-    username: {{docker-username}}
-    password: {{docker-password}}
-    repository: {{concourse-tasks-repository}}
+    email: ((docker-email))
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: ((concourse-tasks-repository))
 
 - name: oracle-image-git-repository
   type: git
   source:
-    uri: {{oracle-image-git-repository}}
-    branch: {{oracle-image-git-repository-branch}}
+    uri: ((oracle-image-git-repository))
+    branch: ((oracle-image-git-repository-branch))
 
 - name: oracle-image-repository
   type: docker-image
   source:
-    email: {{docker-email}}
-    username: {{docker-username}}
-    password: {{docker-password}}
-    repository: {{oracle-image-repository}}
+    email: ((docker-email))
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: ((oracle-image-repository))
 
 - name: s3-resource-simple-repository
   type: git
   source:
-    uri: {{s3-resource-simple-git-repository}}
-    branch: {{s3-resource-simple-git-repository-branch}}
+    uri: ((s3-resource-simple-git-repository))
+    branch: ((s3-resource-simple-git-repository-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: s3-resource-simple-repo
   type: docker-image
   source:
-    email: {{docker-email}}
-    username: {{docker-username}}
-    password: {{docker-password}}
-    repository: {{s3-resource-simple-image-repository}}
+    email: ((docker-email))
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: ((s3-resource-simple-image-repository))
 
 - name: concourse-image-version
   type: semver
   source:
     driver: s3
-    bucket: {{semver-bucket}}
+    bucket: ((semver-bucket))
     key: concourse-docker-image-version
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    region_name: {{aws-region}}
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
     initial_version: 1.0.0
 
 - name: hardened-concourse-image-staging-version
   type: semver
   source:
     driver: s3
-    bucket: {{semver-bucket}}
+    bucket: ((semver-bucket))
     key: harden-concourse-docker-image-version-staging
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    region_name: {{aws-region}}
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
     initial_version: 1.0.0
 
 - name: hardened-s3-resource-simple-image-version-staging
   type: semver
   source:
     driver: s3
-    bucket: {{semver-bucket}}
+    bucket: ((semver-bucket))
     key: harden-s3-resource-simple-image-version-staging
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    region_name: {{aws-region}}
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
     initial_version: 1.0.0
 
 - name: s3-image-version
   type: semver
   source:
     driver: s3
-    bucket: {{semver-bucket}}
+    bucket: ((semver-bucket))
     key: s3-docker-image-version
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    region_name: {{aws-region}}
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
     initial_version: 1.2.0
 
 - name: oracle-image-version
   type: semver
   source:
     driver: s3
-    bucket: {{semver-bucket}}
+    bucket: ((semver-bucket))
     key: oracle-docker-image-version
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    region_name: {{aws-region}}
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
     initial_version: 1.0.0
 
 - name: sql-client-image-version
   type: semver
   source:
     driver: s3
-    bucket: {{semver-bucket}}
+    bucket: ((semver-bucket))
     key: sql-client-docker-image-version
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    region_name: {{aws-region}}
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
     initial_version: 1.0.0


### PR DESCRIPTION
## Changes proposed in this pull request:
- Makes the pipeline self-flying
- Updates the variables to work with credhub
- Removes the old_name key since it is no longer needed

## security considerations
Improves security by using credhub as centralized source of truth
