### PR TITLE
Switch yq test from package to command

### DIFF
--- a/task/harden-concourse-tasks/scripts/build.sh
+++ b/task/harden-concourse-tasks/scripts/build.sh
@@ -69,7 +69,6 @@ apt-get -y -q install \
   whois \
   rsync \
   libffi-dev \
-  yq \
   python3-pip \
 
 apt-get clean

--- a/task/harden-concourse-tasks/scripts/test.sh
+++ b/task/harden-concourse-tasks/scripts/test.sh
@@ -40,7 +40,6 @@ test_package libyaml-dev
 test_package openssl
 test_package sqlite3
 test_package unzip
-test_package yq
 test_package zlib1g-dev
 test_package python3-pip
 
@@ -63,3 +62,4 @@ test_command terraform "$TERRAFORM_CMD_VERSION"
 test_command uaac "$UAAC_CMD_VERSION"
 test_command unzip "$UNZIP_CMD_VERSION"
 test_command go "$GO_CMD_VERSION" version
+test_command yq "$YQ_VERSION"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switching from testing that the yq package exists to testing that you can run the command
- Also removing yq from apt-get install since we are no longer using the PPA package

## security considerations
None
